### PR TITLE
[BUGFIX] When filename contained a german umlaut or other special charac...

### DIFF
--- a/displayFileLinks.php
+++ b/displayFileLinks.php
@@ -86,7 +86,7 @@ function user_displayFileLinks($markerArray, $conf) {
 			$fileProperties['readableName'] = str_replace(array('_'), array(' '), $fileNameParts['filename']);
 
 			$local_cObj->start($fileProperties);
-			$filelinks .= $local_cObj->filelink($file->getPublicUrl(), $conf_newsFiles);
+			$filelinks .= $local_cObj->filelink(rawurldecode($file->getPublicUrl()), $conf_newsFiles);
 		}
 
 		if ($filelinks) {


### PR DESCRIPTION
...ters file links were not generated

The value of $file->getPublicUrl() is raw url encoded in TYPO3,
therefore the check whether the file exists in
\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer->filelink(…)
failed when the file name contained any special characters (i.e..
german umlauts).
