### PR TITLE
[BUGFIX] Use properties of the original file in addition to the refer…

### DIFF
--- a/imageMarkerFunc.php
+++ b/imageMarkerFunc.php
@@ -115,7 +115,7 @@ function user_imageMarkerFunc($paramArray, $conf) {
 			break;
 		}
 		if ($val) {
-			$reference = $val->getReferenceProperties();
+			$reference = array_merge(array_filter($val->getOriginalFile()->getProperties(), 'strval'), array_filter($val->getReferenceProperties(), 'strval'));
 			//set Caption, Alt-text and Title Tag
 			switch ($mode) {
 				//take data form tt_news record


### PR DESCRIPTION
…ence properties.

The sys_file_reference table only contains the property overrides of the reference not the original property values from sys_file_metadata.

The array_filter function here is used to ensure that the original properties are only overwritten by the reference properties if there are valid string values in title, description, etc.
